### PR TITLE
DateTime Processing

### DIFF
--- a/idrac-input.conf
+++ b/idrac-input.conf
@@ -2,7 +2,7 @@
   [[processors.regex.fields]]
     key = "log-dates"
     pattern = "^(?P<YYYY>\\d{4})(?P<MM>\\d{2})(?P<DD>\\d{2})(?P<HH>\\d{2})(?P<mm>\\d{2})(?P<ss>\\d{2})\\.(?P<SSSSSS>\\d{6})(?P<ZZ>[-+]\\d{3,4})$"
-    replacement = "${YYYY}-${MM}-${DD} ${HH}:${mm}:${ss}.${SSSSSS}${ZZ}"
+    replacement = "${YYYY}-${MM}-${DD} ${HH}:${mm}:${ss}"
 
 [[inputs.snmp]]
   agents = [ "idracURL1:161" , "idracURL2:161" , "idracURL3:161" ]

--- a/idrac-input.conf
+++ b/idrac-input.conf
@@ -1,3 +1,9 @@
+[[processors.regex]]
+  [[processors.regex.fields]]
+    key = "log-dates"
+    pattern = "^(?P<YYYY>\\d{4})(?P<MM>\\d{2})(?P<DD>\\d{2})(?P<HH>\\d{2})(?P<mm>\\d{2})(?P<ss>\\d{2})\\.(?P<SSSSSS>\\d{6})(?P<ZZ>[-+]\\d{3,4})$"
+    replacement = "${YYYY}-${MM}-${DD} ${HH}:${mm}:${ss}.${SSSSSS}${ZZ}"
+
 [[inputs.snmp]]
   agents = [ "idracURL1:161" , "idracURL2:161" , "idracURL3:161" ]
   version = 1


### PR DESCRIPTION
Uses telegraf regex processor to reformat date and time into something Grafana can understand.
Just need to update the visualization option to date and select the desired date format.