### PR TITLE
inlet/exhaust and cpu1/cpu2 inverted

### DIFF
--- a/idrac-input.conf
+++ b/idrac-input.conf
@@ -160,19 +160,19 @@
      oid  = ".1.3.6.1.4.1.674.10892.5.4.700.12.1.6.1.6"
  
   [[inputs.snmp.field]]
-     name = "inlet-temp"
+     name = "cpu1-temp"
      oid  = ".1.3.6.1.4.1.674.10892.5.4.700.20.1.6.1.1"
 
   [[inputs.snmp.field]]
-     name = "exhaust-temp"
+     name = "cpu2-temp"
      oid  = ".1.3.6.1.4.1.674.10892.5.4.700.20.1.6.1.2"
 
   [[inputs.snmp.field]]
-     name = "cpu1-temp"
+     name = "inlet-temp"
      oid  = ".1.3.6.1.4.1.674.10892.5.4.700.20.1.6.1.3"
 
   [[inputs.snmp.field]]
-     name = "cpu2-temp"
+     name = "exhaust-temp"
      oid  = ".1.3.6.1.4.1.674.10892.5.4.700.20.1.6.1.4"
 
   [[inputs.snmp.field]]


### PR DESCRIPTION
I found that the temperature values displayed for inlet was not identical to what the web interface displayed. It turns out that the cpu's oids were reversed with inlet and exhaust. 

PowerEdge R740xd 
BIOS 2.5.4
idrac 4.10.10.10